### PR TITLE
Cross-compile Windows Fix

### DIFF
--- a/src/oatpp-sqlite/mapping/Serializer.cpp
+++ b/src/oatpp-sqlite/mapping/Serializer.cpp
@@ -27,7 +27,7 @@
 #include "oatpp-sqlite/Types.hpp"
 
 #if defined(WIN32) || defined(_WIN32)
-  #include <WinSock2.h>
+  #include <winsock2.h>
 #else
   #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
When cross-compiling using clang on Linux to target Windows, the build fails due to the mixed case spelling of the header includes. Clang expects the headers to be all lowercase.